### PR TITLE
fix: ensure baseUrl has trailing / for proper URL creation

### DIFF
--- a/src/catalog/IcebergRestCatalog.ts
+++ b/src/catalog/IcebergRestCatalog.ts
@@ -85,8 +85,10 @@ export class IcebergRestCatalog {
       prefix += `/${options.catalogName}`
     }
 
+    const baseUrl = options.baseUrl.endsWith('/') ? options.baseUrl : `${options.baseUrl}/`
+
     this.client = createFetchClient({
-      baseUrl: options.baseUrl,
+      baseUrl,
       auth: options.auth,
       fetchImpl: options.fetch,
     })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix, related to #8 the URL doesn't get created properly when leaving off a trailing `/` in the `baseUrl`

## What is the current behavior?

If you leave off a trailing `/` in the`baseUrl` the last path gets chopped off due to how `new URL(path, baseUrl)` works which gets called in `buildUrl` e.g. for list namespaces

```js
baseUrl = "https://example.com/storage/iceberg"
url = "https://example.com/storage/v1/warehouse/namespaces" // iceberg gets removed
```

## What is the new behavior?

New behavior always ensures the baseUrl ends with a trialing `/` so it will function the same if you pass in with or without a trailing `/`

```js
baseUrl = "https://example.com/storage/iceberg"
url = "https://example.com/storage/iceberg/v1/warehouse/namespaces" // iceberg stays
```

## Additional context

