### PR TITLE
feat: add purge flag to dropTable method

### DIFF
--- a/src/catalog/IcebergRestCatalog.ts
+++ b/src/catalog/IcebergRestCatalog.ts
@@ -9,6 +9,7 @@ import type {
   TableIdentifier,
   TableMetadata,
   UpdateTableRequest,
+  DropTableRequest,
 } from './types'
 
 /**
@@ -254,8 +255,8 @@ export class IcebergRestCatalog {
    * await catalog.dropTable({ namespace: ['analytics'], name: 'events' });
    * ```
    */
-  async dropTable(id: TableIdentifier): Promise<void> {
-    await this.tableOps.dropTable(id)
+  async dropTable(id: TableIdentifier, options?: DropTableRequest): Promise<void> {
+    await this.tableOps.dropTable(id, options)
   }
 
   /**

--- a/src/catalog/tables.ts
+++ b/src/catalog/tables.ts
@@ -7,6 +7,7 @@ import type {
   TableIdentifier,
   TableMetadata,
   UpdateTableRequest,
+  DropTableRequest,
 } from './types'
 
 function namespaceToPath(namespace: string[]): string {
@@ -58,10 +59,11 @@ export class TableOperations {
     return response.data.metadata
   }
 
-  async dropTable(id: TableIdentifier): Promise<void> {
+  async dropTable(id: TableIdentifier, options?: DropTableRequest): Promise<void> {
     await this.client.request<void>({
       method: 'DELETE',
       path: `${this.prefix}/namespaces/${namespaceToPath(id.namespace)}/tables/${id.name}`,
+      query: { purgeRequested: String(options?.purge ?? false) },
     })
   }
 

--- a/src/catalog/types.ts
+++ b/src/catalog/types.ts
@@ -81,6 +81,10 @@ export interface UpdateTableRequest {
   properties?: Record<string, string>
 }
 
+export interface DropTableRequest {
+  purge?: boolean
+}
+
 export interface TableMetadata {
   name?: string
   location: string

--- a/test/catalog/tables.test.ts
+++ b/test/catalog/tables.test.ts
@@ -352,6 +352,25 @@ describe('TableOperations', () => {
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
         path: '/v1/namespaces/analytics/tables/events',
+        query: {purgeRequested: "false"}
+      })
+    })
+
+    it('should drop a table with purge set to true', async () => {
+      const mockClient = createMockClient()
+      vi.mocked(mockClient.request).mockResolvedValue({
+        status: 204,
+        headers: new Headers(),
+        data: undefined,
+      })
+
+      const ops = new TableOperations(mockClient, '/v1')
+      await ops.dropTable({ namespace: ['analytics'], name: 'events' }, {purge: true})
+
+      expect(mockClient.request).toHaveBeenCalledWith({
+        method: 'DELETE',
+        path: '/v1/namespaces/analytics/tables/events',
+        query: {purgeRequested: "true"}
       })
     })
 
@@ -369,6 +388,7 @@ describe('TableOperations', () => {
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
         path: '/v1/namespaces/analytics\x1Fprod/tables/events',
+        query: {purgeRequested: "false"}
       })
     })
   })


### PR DESCRIPTION
## What kind of change does this PR introduce?
Adds the ability to specify if you want `purgeRequested` set to true or false on the drop table operation.

## What is the current behavior?
Currently there is no way to configure the `purgeRequested` query parameter when dropping a table. The API endpoint supports this parameter to optionally purge the table's data.

## What is the new behavior?
Users can now pass an optional `options` parameter to `dropTable()` with a `purge` boolean flag:

```js
// Purge table data (purgeRequested=true)
await catalog.dropTable({ namespace: ['analytics'], name: 'events' }, { purge: true })

// Keep table data (purgeRequested=false, default)
await catalog.dropTable({ namespace: ['analytics'], name: 'events' })
```

The `purge` option is mapped to the `purgeRequested` query parameter expected by the Iceberg REST API. Let me know if we'd prefer to just keep it as the queryParameter.

## Additional Context

<img width="834" height="154" alt="image" src="https://github.com/user-attachments/assets/748bb022-adb7-41dc-a583-e81bec4e42d4" />
