### PR TITLE
docs: correct updateTable return type in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ const metadata = await catalog.loadTable({
 })
 ```
 
-#### `updateTable(id: TableIdentifier, request: UpdateTableRequest): Promise<TableMetadata>`
+#### `updateTable(id: TableIdentifier, request: UpdateTableRequest): Promise<CommitTableResponse>`
 
 Update table metadata (schema, partition spec, or properties).
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Type fix in readme.

## What is the current behavior?

`updateTable` has wrong return type, was changed in #22.

## What is the new behavior?

It has the correct return type.

## Additional context

fixes #29
