### PR TITLE
feat: support warehouse option

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ Creates a new catalog client instance.
 
 - `baseUrl` (string, required): Base URL of the REST catalog
 - `auth` (AuthConfig, optional): Authentication configuration
-- `warehouse` (string, optional): warehouse location or identifier to request
 - `catalogName` (string, optional): Catalog name for multi-catalog servers. When specified, requests are sent to `{baseUrl}/v1/{catalogName}/...`. For example, with `baseUrl: 'https://host.com'` and `catalogName: 'prod'`, requests go to `https://host.com/v1/prod/namespaces`
+- `warehouse` (string, optional): warehouse location or identifier to request
 - `fetch` (typeof fetch, optional): Custom fetch implementation
 - `accessDelegation` (AccessDelegation[], optional): Access delegation mechanisms to request from the server
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Creates a new catalog client instance.
 
 - `baseUrl` (string, required): Base URL of the REST catalog
 - `auth` (AuthConfig, optional): Authentication configuration
+- `warehouse` (string, optional): warehouse location or identifier to request
 - `catalogName` (string, optional): Catalog name for multi-catalog servers. When specified, requests are sent to `{baseUrl}/v1/{catalogName}/...`. For example, with `baseUrl: 'https://host.com'` and `catalogName: 'prod'`, requests go to `https://host.com/v1/prod/namespaces`
 - `fetch` (typeof fetch, optional): Custom fetch implementation
 - `accessDelegation` (AccessDelegation[], optional): Access delegation mechanisms to request from the server

--- a/src/catalog/IcebergRestCatalog.ts
+++ b/src/catalog/IcebergRestCatalog.ts
@@ -126,7 +126,6 @@ export class IcebergRestCatalog {
       return
     }
 
-    // https://github.com/apache/iceberg/blob/apache-iceberg-1.10.0/open-api/rest-catalog-open-api.yaml#L65
     const response = await this.client.request<CatalogConfig>({
       method: 'GET',
       path: `v1/config`,

--- a/src/catalog/IcebergRestCatalog.ts
+++ b/src/catalog/IcebergRestCatalog.ts
@@ -140,7 +140,7 @@ export class IcebergRestCatalog {
 
     // Apply prefix override from server response
     // https://github.com/apache/iceberg/blob/apache-iceberg-1.10.0/open-api/rest-catalog-open-api.yaml#L105-L134
-    if (config.overrides?.prefix) {
+    if (config.overrides.prefix) {
       const prefix = `v1/${config.overrides.prefix}`
       // Re-initialize operations with the new prefix
       this.namespaceOps = new NamespaceOperations(this.client, prefix)

--- a/src/catalog/IcebergRestCatalog.ts
+++ b/src/catalog/IcebergRestCatalog.ts
@@ -29,10 +29,10 @@ export type AccessDelegation = 'vended-credentials' | 'remote-signing'
 export interface IcebergRestCatalogOptions {
   /** Base URL of the Iceberg REST Catalog API */
   baseUrl: string
-  /** Optional warehouse location or identifier to request */
-  warehouse?: string
   /** Optional catalog name prefix for multi-catalog servers */
   catalogName?: string
+  /** Optional warehouse location or identifier to request */
+  warehouse?: string
   /** Authentication configuration */
   auth?: AuthConfig
   /** Custom fetch implementation (defaults to globalThis.fetch) */

--- a/src/catalog/IcebergRestCatalog.ts
+++ b/src/catalog/IcebergRestCatalog.ts
@@ -81,7 +81,7 @@ export class IcebergRestCatalog {
 
   private namespaceOps: NamespaceOperations
   private tableOps: TableOperations
-  private warehouseEnabled: boolean = false
+  private configFetched: boolean = false
 
   /**
    * Creates a new Iceberg REST Catalog client.
@@ -117,16 +117,14 @@ export class IcebergRestCatalog {
    * This is called automatically before each operation (lazy initialization).
    */
   private async ensureInitialized(): Promise<void> {
-    if (this.warehouse) {
-      await this.useWarehouse()
-    }
+    await this.fetchConfig()
   }
 
   /**
-   * Configures the catalog client with warehouse-specific settings from the server.
+   * Call Configuration API to get catalog configuration properties from the server.
    */
-  private async useWarehouse(): Promise<void> {
-    if (this.warehouseEnabled) {
+  private async fetchConfig(): Promise<void> {
+    if (this.configFetched) {
       return
     }
 
@@ -147,7 +145,7 @@ export class IcebergRestCatalog {
       this.tableOps = new TableOperations(this.client, prefix, this.accessDelegation)
     }
 
-    this.warehouseEnabled = true
+    this.configFetched = true
   }
 
   /**

--- a/src/catalog/namespaces.ts
+++ b/src/catalog/namespaces.ts
@@ -9,6 +9,10 @@ import type {
   NamespaceMetadata,
 } from './types'
 
+function constructPath(...parts: string[]): string {
+  return parts.filter((p) => p).join('/')
+}
+
 function namespaceToPath(namespace: string[]): string {
   return namespace.join('\x1F')
 }
@@ -24,7 +28,7 @@ export class NamespaceOperations {
 
     const response = await this.client.request<ListNamespacesResponse>({
       method: 'GET',
-      path: `${this.prefix}/namespaces`,
+      path: constructPath('v1', this.prefix, 'namespaces'),
       query,
     })
 
@@ -42,7 +46,7 @@ export class NamespaceOperations {
 
     const response = await this.client.request<CreateNamespaceResponse>({
       method: 'POST',
-      path: `${this.prefix}/namespaces`,
+      path: constructPath('v1', this.prefix, 'namespaces'),
       body: request,
     })
 
@@ -52,14 +56,14 @@ export class NamespaceOperations {
   async dropNamespace(id: NamespaceIdentifier): Promise<void> {
     await this.client.request<void>({
       method: 'DELETE',
-      path: `${this.prefix}/namespaces/${namespaceToPath(id.namespace)}`,
+      path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(id.namespace)),
     })
   }
 
   async loadNamespaceMetadata(id: NamespaceIdentifier): Promise<NamespaceMetadata> {
     const response = await this.client.request<GetNamespaceResponse>({
       method: 'GET',
-      path: `${this.prefix}/namespaces/${namespaceToPath(id.namespace)}`,
+      path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(id.namespace)),
     })
 
     return {
@@ -71,7 +75,7 @@ export class NamespaceOperations {
     try {
       await this.client.request<void>({
         method: 'HEAD',
-        path: `${this.prefix}/namespaces/${namespaceToPath(id.namespace)}`,
+        path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(id.namespace)),
       })
       return true
     } catch (error) {

--- a/src/catalog/tables.ts
+++ b/src/catalog/tables.ts
@@ -12,6 +12,10 @@ import type {
   DropTableRequest,
 } from './types'
 
+function constructPath(...parts: string[]): string {
+  return parts.filter((p) => p).join('/')
+}
+
 function namespaceToPath(namespace: string[]): string {
   return namespace.join('\x1F')
 }
@@ -26,7 +30,7 @@ export class TableOperations {
   async listTables(namespace: NamespaceIdentifier): Promise<TableIdentifier[]> {
     const response = await this.client.request<ListTablesResponse>({
       method: 'GET',
-      path: `${this.prefix}/namespaces/${namespaceToPath(namespace.namespace)}/tables`,
+      path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(namespace.namespace), 'tables'),
     })
 
     return response.data.identifiers
@@ -43,7 +47,7 @@ export class TableOperations {
 
     const response = await this.client.request<LoadTableResponse>({
       method: 'POST',
-      path: `${this.prefix}/namespaces/${namespaceToPath(namespace.namespace)}/tables`,
+      path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(namespace.namespace), 'tables'),
       body: request,
       headers,
     })
@@ -57,7 +61,7 @@ export class TableOperations {
   ): Promise<CommitTableResponse> {
     const response = await this.client.request<LoadTableResponse>({
       method: 'POST',
-      path: `${this.prefix}/namespaces/${namespaceToPath(id.namespace)}/tables/${id.name}`,
+      path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(id.namespace), 'tables', id.name),
       body: request,
     })
 
@@ -70,7 +74,7 @@ export class TableOperations {
   async dropTable(id: TableIdentifier, options?: DropTableRequest): Promise<void> {
     await this.client.request<void>({
       method: 'DELETE',
-      path: `${this.prefix}/namespaces/${namespaceToPath(id.namespace)}/tables/${id.name}`,
+      path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(id.namespace), 'tables', id.name),
       query: { purgeRequested: String(options?.purge ?? false) },
     })
   }
@@ -83,7 +87,7 @@ export class TableOperations {
 
     const response = await this.client.request<LoadTableResponse>({
       method: 'GET',
-      path: `${this.prefix}/namespaces/${namespaceToPath(id.namespace)}/tables/${id.name}`,
+      path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(id.namespace), 'tables', id.name),
       headers,
     })
 
@@ -99,7 +103,7 @@ export class TableOperations {
     try {
       await this.client.request<void>({
         method: 'HEAD',
-        path: `${this.prefix}/namespaces/${namespaceToPath(id.namespace)}/tables/${id.name}`,
+        path: constructPath('v1', this.prefix, 'namespaces', namespaceToPath(id.namespace), 'tables', id.name),
         headers,
       })
       return true

--- a/src/catalog/types.ts
+++ b/src/catalog/types.ts
@@ -299,9 +299,10 @@ export interface CommitTableResponse {
  * Response from the catalog configuration endpoint (GET /v1/config).
  */
 export interface CatalogConfig {
-  defaults?: Record<string, string>
-  overrides?: Record<string, string>
+  defaults: Record<string, string>
+  overrides: Record<string, string>
   endpoints?: string[]
+  'idempotency-key-lifetime'?: string
 }
 
 /**

--- a/src/catalog/types.ts
+++ b/src/catalog/types.ts
@@ -296,6 +296,15 @@ export interface CommitTableResponse {
 }
 
 /**
+ * Response from the catalog configuration endpoint (GET /v1/config).
+ */
+export interface CatalogConfig {
+  defaults?: Record<string, string>
+  overrides?: Record<string, string>
+  endpoints?: string[]
+}
+
+/**
  * Gets the current (active) schema from table metadata.
  *
  * @param metadata - Table metadata containing schemas array and current-schema-id

--- a/test/catalog/IcebergRestCatalog.test.ts
+++ b/test/catalog/IcebergRestCatalog.test.ts
@@ -190,36 +190,6 @@ describe('IcebergRestCatalog', () => {
           expect.objectContaining({ method: 'GET' })
         )
       })
-
-      it('should handle config response with empty overrides', async () => {
-        const catalog = createCatalog({ warehouse: 'my-warehouse' })
-
-        // Mock config response with empty overrides
-        mockFetch.mockReturnValueOnce(
-          mockFetchResponse({
-            defaults: {},
-            // overrides is undefined
-          })
-        )
-        // Mock namespace list response
-        mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [] }))
-
-        await catalog.listNamespaces()
-
-        // First call should be config with warehouse query param
-        expect(mockFetch).toHaveBeenNthCalledWith(
-          1,
-          'https://catalog.example.com/v1/config?warehouse=my-warehouse',
-          expect.objectContaining({ method: 'GET' })
-        )
-
-        // Should use default v1 prefix
-        expect(mockFetch).toHaveBeenNthCalledWith(
-          2,
-          'https://catalog.example.com/v1/namespaces',
-          expect.objectContaining({ method: 'GET' })
-        )
-      })
     })
   })
 

--- a/test/catalog/IcebergRestCatalog.test.ts
+++ b/test/catalog/IcebergRestCatalog.test.ts
@@ -299,5 +299,65 @@ describe('IcebergRestCatalog', () => {
         )
       })
     })
+
+    describe('configuration API failed', () => {
+      it('should throw error when config endpoint returns 401', async () => {
+        const catalog = createCatalog({})
+
+        mockFetch.mockReturnValueOnce(
+          mockFetchResponse(
+            {
+              error: {
+                message: 'Unauthorized',
+                type: 'UnauthorizedException',
+                code: 401,
+              },
+            },
+            401
+          )
+        )
+
+        await expect(catalog.listNamespaces()).rejects.toThrow('Unauthorized')
+      })
+
+      it('should throw error when config endpoint returns 404', async () => {
+        const catalog = createCatalog({})
+
+        mockFetch.mockReturnValueOnce(
+          mockFetchResponse(
+            {
+              error: {
+                message: 'Configuration endpoint not found',
+                type: 'NoSuchResourceException',
+                code: 404,
+              },
+            },
+            404
+          )
+        )
+        mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [['analytics']] }))
+
+        await expect(catalog.listNamespaces()).rejects.toThrow('Configuration endpoint not found')
+      })
+
+      it('should throw error when config endpoint returns 500', async () => {
+        const catalog = createCatalog({})
+
+        mockFetch.mockReturnValueOnce(
+          mockFetchResponse(
+            {
+              error: {
+                message: 'Internal Server Error',
+                type: 'InternalServerException',
+                code: 500,
+              },
+            },
+            500
+          )
+        )
+
+        await expect(catalog.listNamespaces()).rejects.toThrow('Internal Server Error')
+      })
+    })
   })
 })

--- a/test/catalog/IcebergRestCatalog.test.ts
+++ b/test/catalog/IcebergRestCatalog.test.ts
@@ -1,0 +1,317 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { IcebergRestCatalog } from '../../src/catalog/IcebergRestCatalog'
+
+describe('IcebergRestCatalog', () => {
+  let mockFetch: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockFetch = vi.fn()
+  })
+
+  const createCatalog = (options: {
+    baseUrl?: string
+    warehouse?: string
+    catalogName?: string
+  }) => {
+    return new IcebergRestCatalog({
+      baseUrl: options.baseUrl ?? 'https://catalog.example.com',
+      warehouse: options.warehouse,
+      catalogName: options.catalogName,
+      fetch: mockFetch as unknown as typeof fetch,
+    })
+  }
+
+  const mockFetchResponse = (data: unknown, status = 200) => {
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      text: () => Promise.resolve(JSON.stringify(data)),
+    })
+  }
+
+  describe('warehouse option', () => {
+    describe('without warehouse', () => {
+      it('should not call /v1/config when warehouse is not provided', async () => {
+        const catalog = createCatalog({})
+
+        // Mock namespace list response
+        mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [['default']] }))
+
+        await catalog.listNamespaces()
+
+        // Should only have one call (listNamespaces), no config call
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        expect(mockFetch).toHaveBeenCalledWith(
+          'https://catalog.example.com/v1/namespaces',
+          expect.objectContaining({ method: 'GET' })
+        )
+      })
+    })
+
+    describe('with warehouse', () => {
+      it('should call /v1/config with warehouse query param on first operation', async () => {
+        const catalog = createCatalog({ warehouse: 'my-warehouse' })
+
+        // Mock config response (no prefix override)
+        mockFetch.mockReturnValueOnce(
+          mockFetchResponse({
+            defaults: {},
+            overrides: {},
+          })
+        )
+        // Mock namespace list response
+        mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [['default']] }))
+
+        await catalog.listNamespaces()
+
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+
+        // First call should be config with warehouse query param
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          1,
+          'https://catalog.example.com/v1/config?warehouse=my-warehouse',
+          expect.objectContaining({ method: 'GET' })
+        )
+
+        // Second call should be namespace list
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          2,
+          'https://catalog.example.com/v1/namespaces',
+          expect.objectContaining({ method: 'GET' })
+        )
+      })
+
+      it('should apply prefix override from config response', async () => {
+        const catalog = createCatalog({ warehouse: 'my-warehouse' })
+
+        // Mock config response WITH prefix override
+        mockFetch.mockReturnValueOnce(
+          mockFetchResponse({
+            defaults: {},
+            overrides: {
+              prefix: 'account123/bucket456',
+            },
+          })
+        )
+        // Mock namespace list response
+        mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [['analytics']] }))
+
+        await catalog.listNamespaces()
+
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+
+        // First call should be config with warehouse query param
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          1,
+          'https://catalog.example.com/v1/config?warehouse=my-warehouse',
+          expect.objectContaining({ method: 'GET' })
+        )
+
+        // Second call should use the prefix from config
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          2,
+          'https://catalog.example.com/v1/account123/bucket456/namespaces',
+          expect.objectContaining({ method: 'GET' })
+        )
+      })
+
+      it('should only call config once (lazy initialization)', async () => {
+        const catalog = createCatalog({ warehouse: 'my-warehouse' })
+
+        // Mock config response WITH prefix override
+        mockFetch.mockReturnValueOnce(
+          mockFetchResponse({
+            defaults: {},
+            overrides: {
+              prefix: 'account123/bucket456',
+            },
+          })
+        )
+        // Mock namespace list response
+        mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [['analytics']] }))
+        // Mock listTables response
+        mockFetch.mockReturnValueOnce(mockFetchResponse({ identifiers: ['my_table'] }))
+
+        await catalog.listNamespaces()
+        await catalog.listTables({ namespace: ['analytics'] })
+
+        expect(mockFetch).toHaveBeenCalledTimes(3)
+
+        // First call should be config with warehouse query param
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          1,
+          'https://catalog.example.com/v1/config?warehouse=my-warehouse',
+          expect.objectContaining({ method: 'GET' })
+        )
+
+        // Second call should use the prefix from config
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          2,
+          'https://catalog.example.com/v1/account123/bucket456/namespaces',
+          expect.objectContaining({ method: 'GET' })
+        )
+
+        // Third call should be listTables with prefix (no additional config call)
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          3,
+          'https://catalog.example.com/v1/account123/bucket456/namespaces/analytics/tables',
+          expect.objectContaining({ method: 'GET' })
+        )
+      })
+
+      it('should work without prefix in config response', async () => {
+        const catalog = createCatalog({ warehouse: 'my-warehouse' })
+
+        // Mock config response without prefix
+        mockFetch.mockReturnValueOnce(
+          mockFetchResponse({
+            defaults: { 'some-default': 'value' },
+            overrides: { 'some-override': 'value' },
+            // No prefix key
+          })
+        )
+        // Mock namespace list response
+        mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [] }))
+
+        await catalog.listNamespaces()
+
+        // First call should be config with warehouse query param
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          1,
+          'https://catalog.example.com/v1/config?warehouse=my-warehouse',
+          expect.objectContaining({ method: 'GET' })
+        )
+
+        // Should use default v1 prefix (no extra path segment)
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          2,
+          'https://catalog.example.com/v1/namespaces',
+          expect.objectContaining({ method: 'GET' })
+        )
+      })
+
+      it('should handle config response with empty overrides', async () => {
+        const catalog = createCatalog({ warehouse: 'my-warehouse' })
+
+        // Mock config response with empty overrides
+        mockFetch.mockReturnValueOnce(
+          mockFetchResponse({
+            defaults: {},
+            // overrides is undefined
+          })
+        )
+        // Mock namespace list response
+        mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [] }))
+
+        await catalog.listNamespaces()
+
+        // First call should be config with warehouse query param
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          1,
+          'https://catalog.example.com/v1/config?warehouse=my-warehouse',
+          expect.objectContaining({ method: 'GET' })
+        )
+
+        // Should use default v1 prefix
+        expect(mockFetch).toHaveBeenNthCalledWith(
+          2,
+          'https://catalog.example.com/v1/namespaces',
+          expect.objectContaining({ method: 'GET' })
+        )
+      })
+    })
+  })
+
+  describe('catalogName option', () => {
+    it('should use catalogName as prefix when provided without warehouse', async () => {
+      const catalog = createCatalog({ catalogName: 'prod' })
+
+      // Mock namespace list response
+      mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [['default']] }))
+
+      await catalog.listNamespaces()
+
+      // Should only have one call (listNamespaces), no config call
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://catalog.example.com/v1/prod/namespaces',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+  })
+
+  describe('warehouse + catalogName combination', () => {
+    it('should override catalogName with config prefix when warehouse returns prefix', async () => {
+      const catalog = createCatalog({
+        warehouse: 'my-warehouse',
+        catalogName: 'initial-catalog',
+      })
+
+      // Mock config response WITH prefix override
+      mockFetch.mockReturnValueOnce(
+        mockFetchResponse({
+          defaults: {},
+          overrides: {
+            prefix: 'server-provided-prefix',
+          },
+        })
+      )
+      // Mock namespace list response
+      mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [['analytics']] }))
+
+      await catalog.listNamespaces()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      // First call should be config with warehouse query param
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://catalog.example.com/v1/config?warehouse=my-warehouse',
+        expect.objectContaining({ method: 'GET' })
+      )
+
+      // Second call should use server-provided prefix (NOT catalogName)
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://catalog.example.com/v1/server-provided-prefix/namespaces',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+
+    it('should keep catalogName when warehouse config has no prefix override', async () => {
+      const catalog = createCatalog({
+        warehouse: 'my-warehouse',
+        catalogName: 'initial-catalog',
+      })
+
+      // Mock config response WITHOUT prefix override
+      mockFetch.mockReturnValueOnce(
+        mockFetchResponse({
+          defaults: {},
+          overrides: {},
+        })
+      )
+      // Mock namespace list response
+      mockFetch.mockReturnValueOnce(mockFetchResponse({ namespaces: [['analytics']] }))
+
+      await catalog.listNamespaces()
+
+      expect(mockFetch).toHaveBeenCalledTimes(2)
+
+      // First call should be config with warehouse query param
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        1,
+        'https://catalog.example.com/v1/config?warehouse=my-warehouse',
+        expect.objectContaining({ method: 'GET' })
+      )
+
+      // Second call should still use catalogName since no prefix override
+      expect(mockFetch).toHaveBeenNthCalledWith(
+        2,
+        'https://catalog.example.com/v1/initial-catalog/namespaces',
+        expect.objectContaining({ method: 'GET' })
+      )
+    })
+  })
+})

--- a/test/catalog/namespaces.test.ts
+++ b/test/catalog/namespaces.test.ts
@@ -19,7 +19,7 @@ describe('NamespaceOperations', () => {
         },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       const result = await ops.listNamespaces()
 
       expect(result).toEqual([
@@ -29,7 +29,7 @@ describe('NamespaceOperations', () => {
       ])
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces',
+        path: 'v1/namespaces',
         query: undefined,
       })
     })
@@ -47,7 +47,7 @@ describe('NamespaceOperations', () => {
         },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       const result = await ops.listNamespaces({ namespace: ['analytics'] })
 
       expect(result).toEqual([
@@ -56,7 +56,7 @@ describe('NamespaceOperations', () => {
       ])
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces',
+        path: 'v1/namespaces',
         query: { parent: 'analytics' },
       })
     })
@@ -71,12 +71,12 @@ describe('NamespaceOperations', () => {
         },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       await ops.listNamespaces({ namespace: ['a', 'b'] })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces',
+        path: 'v1/namespaces',
         query: { parent: 'a\x1Fb' },
       })
     })
@@ -89,12 +89,12 @@ describe('NamespaceOperations', () => {
         data: { namespaces: [] },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1/catalog1')
+      const ops = new NamespaceOperations(mockClient, 'catalog1')
       await ops.listNamespaces()
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/catalog1/namespaces',
+        path: 'v1/catalog1/namespaces',
         query: undefined,
       })
     })
@@ -111,13 +111,13 @@ describe('NamespaceOperations', () => {
         },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       const result = await ops.createNamespace({ namespace: ['analytics'] })
 
       expect(result).toEqual({ namespace: ['analytics'] })
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces',
+        path: 'v1/namespaces',
         body: {
           namespace: ['analytics'],
           properties: undefined,
@@ -136,7 +136,7 @@ describe('NamespaceOperations', () => {
         },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       const result = await ops.createNamespace(
         { namespace: ['analytics'] },
         { properties: { owner: 'team' } }
@@ -148,7 +148,7 @@ describe('NamespaceOperations', () => {
       })
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces',
+        path: 'v1/namespaces',
         body: {
           namespace: ['analytics'],
           properties: { owner: 'team' },
@@ -164,12 +164,12 @@ describe('NamespaceOperations', () => {
         data: { namespace: ['analytics', 'prod'] },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       await ops.createNamespace({ namespace: ['analytics', 'prod'] })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces',
+        path: 'v1/namespaces',
         body: {
           namespace: ['analytics', 'prod'],
           properties: undefined,
@@ -187,12 +187,12 @@ describe('NamespaceOperations', () => {
         data: undefined,
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       await ops.dropNamespace({ namespace: ['analytics'] })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: '/v1/namespaces/analytics',
+        path: 'v1/namespaces/analytics',
       })
     })
 
@@ -204,12 +204,12 @@ describe('NamespaceOperations', () => {
         data: undefined,
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       await ops.dropNamespace({ namespace: ['analytics', 'prod'] })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: '/v1/namespaces/analytics\x1Fprod',
+        path: 'v1/namespaces/analytics\x1Fprod',
       })
     })
   })
@@ -229,7 +229,7 @@ describe('NamespaceOperations', () => {
         },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       const result = await ops.loadNamespaceMetadata({ namespace: ['analytics'] })
 
       expect(result).toEqual({
@@ -240,7 +240,7 @@ describe('NamespaceOperations', () => {
       })
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces/analytics',
+        path: 'v1/namespaces/analytics',
       })
     })
 
@@ -255,12 +255,12 @@ describe('NamespaceOperations', () => {
         },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       await ops.loadNamespaceMetadata({ namespace: ['analytics', 'prod'] })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces/analytics\x1Fprod',
+        path: 'v1/namespaces/analytics\x1Fprod',
       })
     })
   })
@@ -274,13 +274,13 @@ describe('NamespaceOperations', () => {
         data: undefined,
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       const result = await ops.namespaceExists({ namespace: ['analytics'] })
 
       expect(result).toBe(true)
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'HEAD',
-        path: '/v1/namespaces/analytics',
+        path: 'v1/namespaces/analytics',
       })
     })
 
@@ -290,7 +290,7 @@ describe('NamespaceOperations', () => {
         new IcebergError('Not Found', { status: 404 })
       )
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       const result = await ops.namespaceExists({ namespace: ['analytics'] })
 
       expect(result).toBe(false)
@@ -301,7 +301,7 @@ describe('NamespaceOperations', () => {
       const error = new IcebergError('Server Error', { status: 500 })
       vi.mocked(mockClient.request).mockRejectedValue(error)
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
 
       await expect(ops.namespaceExists({ namespace: ['analytics'] })).rejects.toThrow(error)
     })
@@ -319,7 +319,7 @@ describe('NamespaceOperations', () => {
         },
       })
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       await ops.createNamespaceIfNotExists(
         { namespace: ['analytics'] },
         { properties: { owner: 'data-team' } }
@@ -328,7 +328,7 @@ describe('NamespaceOperations', () => {
       expect(mockClient.request).toHaveBeenCalledTimes(1)
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces',
+        path: 'v1/namespaces',
         body: {
           namespace: ['analytics'],
           properties: { owner: 'data-team' },
@@ -342,7 +342,7 @@ describe('NamespaceOperations', () => {
         new IcebergError('Namespace already exists', { status: 409 })
       )
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
       await ops.createNamespaceIfNotExists(
         { namespace: ['analytics'] },
         { properties: { owner: 'data-team' } }
@@ -356,7 +356,7 @@ describe('NamespaceOperations', () => {
       const error = new IcebergError('Server Error', { status: 500 })
       vi.mocked(mockClient.request).mockRejectedValue(error)
 
-      const ops = new NamespaceOperations(mockClient, '/v1')
+      const ops = new NamespaceOperations(mockClient, undefined)
 
       await expect(ops.createNamespaceIfNotExists({ namespace: ['analytics'] })).rejects.toThrow(
         error

--- a/test/catalog/tables.test.ts
+++ b/test/catalog/tables.test.ts
@@ -52,7 +52,7 @@ describe('TableOperations', () => {
         },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       const result = await ops.listTables({ namespace: ['analytics'] })
 
       expect(result).toEqual([
@@ -61,7 +61,7 @@ describe('TableOperations', () => {
       ])
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces/analytics/tables',
+        path: 'v1/namespaces/analytics/tables',
       })
     })
 
@@ -73,12 +73,12 @@ describe('TableOperations', () => {
         data: { identifiers: [] },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.listTables({ namespace: ['analytics', 'prod'] })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces/analytics\x1Fprod/tables',
+        path: 'v1/namespaces/analytics\x1Fprod/tables',
       })
     })
 
@@ -90,12 +90,12 @@ describe('TableOperations', () => {
         data: { identifiers: [] },
       })
 
-      const ops = new TableOperations(mockClient, '/v1/catalog1')
+      const ops = new TableOperations(mockClient, 'catalog1')
       await ops.listTables({ namespace: ['analytics'] })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/catalog1/namespaces/analytics/tables',
+        path: 'v1/catalog1/namespaces/analytics/tables',
       })
     })
   })
@@ -111,7 +111,7 @@ describe('TableOperations', () => {
         },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       const result = await ops.createTable(
         { namespace: ['analytics'] },
         {
@@ -134,7 +134,7 @@ describe('TableOperations', () => {
       expect(result).toEqual(mockTableMetadata)
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces/analytics/tables',
+        path: 'v1/namespaces/analytics/tables',
         body: expect.objectContaining({
           name: 'events',
           schema: expect.any(Object),
@@ -151,7 +151,7 @@ describe('TableOperations', () => {
         data: { metadata: mockTableMetadata },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.createTable(
         { namespace: ['analytics'] },
         {
@@ -177,7 +177,7 @@ describe('TableOperations', () => {
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces/analytics/tables',
+        path: 'v1/namespaces/analytics/tables',
         body: expect.objectContaining({
           'partition-spec': {
             'spec-id': 0,
@@ -203,7 +203,7 @@ describe('TableOperations', () => {
         data: { metadata: mockTableMetadata },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.createTable(
         { namespace: ['analytics'] },
         {
@@ -222,7 +222,7 @@ describe('TableOperations', () => {
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces/analytics/tables',
+        path: 'v1/namespaces/analytics/tables',
         body: expect.objectContaining({
           properties: {
             'write.format.default': 'parquet',
@@ -245,13 +245,13 @@ describe('TableOperations', () => {
         },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       const result = await ops.loadTable({ namespace: ['analytics'], name: 'events' })
 
       expect(result).toEqual(mockTableMetadata)
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces/analytics/tables/events',
+        path: 'v1/namespaces/analytics/tables/events',
         headers: {},
       })
     })
@@ -264,12 +264,12 @@ describe('TableOperations', () => {
         data: { metadata: mockTableMetadata },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.loadTable({ namespace: ['analytics', 'prod'], name: 'events' })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces/analytics\x1Fprod/tables/events',
+        path: 'v1/namespaces/analytics\x1Fprod/tables/events',
         headers: {},
       })
     })
@@ -287,7 +287,7 @@ describe('TableOperations', () => {
         },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       const result = await ops.updateTable(
         { namespace: ['analytics'], name: 'events' },
         {
@@ -301,7 +301,7 @@ describe('TableOperations', () => {
       })
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces/analytics/tables/events',
+        path: 'v1/namespaces/analytics/tables/events',
         body: {
           properties: { 'read.split.target-size': '134217728' },
         },
@@ -319,7 +319,7 @@ describe('TableOperations', () => {
         },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.updateTable(
         { namespace: ['analytics'], name: 'events' },
         {
@@ -337,7 +337,7 @@ describe('TableOperations', () => {
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces/analytics/tables/events',
+        path: 'v1/namespaces/analytics/tables/events',
         body: expect.objectContaining({
           schema: expect.objectContaining({
             'schema-id': 1,
@@ -356,12 +356,12 @@ describe('TableOperations', () => {
         data: undefined,
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.dropTable({ namespace: ['analytics'], name: 'events' })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: '/v1/namespaces/analytics/tables/events',
+        path: 'v1/namespaces/analytics/tables/events',
         query: { purgeRequested: 'false' },
       })
     })
@@ -374,12 +374,12 @@ describe('TableOperations', () => {
         data: undefined,
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.dropTable({ namespace: ['analytics'], name: 'events' }, { purge: true })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: '/v1/namespaces/analytics/tables/events',
+        path: 'v1/namespaces/analytics/tables/events',
         query: { purgeRequested: 'true' },
       })
     })
@@ -392,12 +392,12 @@ describe('TableOperations', () => {
         data: undefined,
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.dropTable({ namespace: ['analytics', 'prod'], name: 'events' })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'DELETE',
-        path: '/v1/namespaces/analytics\x1Fprod/tables/events',
+        path: 'v1/namespaces/analytics\x1Fprod/tables/events',
         query: { purgeRequested: 'false' },
       })
     })
@@ -412,13 +412,13 @@ describe('TableOperations', () => {
         data: undefined,
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       const result = await ops.tableExists({ namespace: ['analytics'], name: 'events' })
 
       expect(result).toBe(true)
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'HEAD',
-        path: '/v1/namespaces/analytics/tables/events',
+        path: 'v1/namespaces/analytics/tables/events',
         headers: {},
       })
     })
@@ -429,7 +429,7 @@ describe('TableOperations', () => {
         new IcebergError('Not Found', { status: 404 })
       )
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       const result = await ops.tableExists({ namespace: ['analytics'], name: 'events' })
 
       expect(result).toBe(false)
@@ -443,12 +443,12 @@ describe('TableOperations', () => {
         data: undefined,
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.tableExists({ namespace: ['analytics', 'prod'], name: 'events' })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'HEAD',
-        path: '/v1/namespaces/analytics\x1Fprod/tables/events',
+        path: 'v1/namespaces/analytics\x1Fprod/tables/events',
         headers: {},
       })
     })
@@ -458,7 +458,7 @@ describe('TableOperations', () => {
       const error = new IcebergError('Server Error', { status: 500 })
       vi.mocked(mockClient.request).mockRejectedValue(error)
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
 
       await expect(ops.tableExists({ namespace: ['analytics'], name: 'events' })).rejects.toThrow(
         error
@@ -475,7 +475,7 @@ describe('TableOperations', () => {
         data: { metadata: mockTableMetadata },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       const result = await ops.createTableIfNotExists(
         { namespace: ['analytics'] },
         {
@@ -498,7 +498,7 @@ describe('TableOperations', () => {
       expect(result).toEqual(mockTableMetadata)
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces/analytics/tables',
+        path: 'v1/namespaces/analytics/tables',
         body: expect.objectContaining({
           name: 'events',
           schema: expect.any(Object),
@@ -517,7 +517,7 @@ describe('TableOperations', () => {
           data: { metadata: mockTableMetadata },
         })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       const result = await ops.createTableIfNotExists(
         { namespace: ['analytics'] },
         {
@@ -534,7 +534,7 @@ describe('TableOperations', () => {
       expect(mockClient.request).toHaveBeenCalledTimes(2)
       expect(mockClient.request).toHaveBeenNthCalledWith(2, {
         method: 'GET',
-        path: '/v1/namespaces/analytics/tables/events',
+        path: 'v1/namespaces/analytics/tables/events',
         headers: {},
       })
     })
@@ -544,7 +544,7 @@ describe('TableOperations', () => {
       const error = new IcebergError('Server Error', { status: 500 })
       vi.mocked(mockClient.request).mockRejectedValue(error)
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
 
       await expect(
         ops.createTableIfNotExists(
@@ -571,7 +571,7 @@ describe('TableOperations', () => {
         data: { metadata: mockTableMetadata },
       })
 
-      const ops = new TableOperations(mockClient, '/v1', 'vended-credentials')
+      const ops = new TableOperations(mockClient, undefined, 'vended-credentials')
       await ops.createTable(
         { namespace: ['analytics'] },
         {
@@ -586,7 +586,7 @@ describe('TableOperations', () => {
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces/analytics/tables',
+        path: 'v1/namespaces/analytics/tables',
         body: expect.any(Object),
         headers: {
           'X-Iceberg-Access-Delegation': 'vended-credentials',
@@ -602,12 +602,12 @@ describe('TableOperations', () => {
         data: { metadata: mockTableMetadata },
       })
 
-      const ops = new TableOperations(mockClient, '/v1', 'vended-credentials,remote-signing')
+      const ops = new TableOperations(mockClient, undefined, 'vended-credentials,remote-signing')
       await ops.loadTable({ namespace: ['analytics'], name: 'events' })
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'GET',
-        path: '/v1/namespaces/analytics/tables/events',
+        path: 'v1/namespaces/analytics/tables/events',
         headers: {
           'X-Iceberg-Access-Delegation': 'vended-credentials,remote-signing',
         },
@@ -622,7 +622,7 @@ describe('TableOperations', () => {
         data: { metadata: mockTableMetadata },
       })
 
-      const ops = new TableOperations(mockClient, '/v1')
+      const ops = new TableOperations(mockClient, undefined)
       await ops.createTable(
         { namespace: ['analytics'] },
         {
@@ -637,7 +637,7 @@ describe('TableOperations', () => {
 
       expect(mockClient.request).toHaveBeenCalledWith({
         method: 'POST',
-        path: '/v1/namespaces/analytics/tables',
+        path: 'v1/namespaces/analytics/tables',
         body: expect.any(Object),
         headers: {},
       })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Support warehouse option and catalog properties handling via configuration API.

## What is the current behavior?

Only support the static catalogName option as prefix.

## What is the new behavior?

In the original java client, the prefix is provided as a catalog property, and used as a path variable. pyiceberg adopts the same implementation.
- java
  - https://github.com/apache/iceberg/blob/26cb7cdd2eff04b5cc7a88b899ee37e7d7f32f18/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java#L233
  - https://github.com/apache/iceberg/blob/26cb7cdd2eff04b5cc7a88b899ee37e7d7f32f18/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java#L53-L60
- pyiceberg
  - https://github.com/apache/iceberg-python/blob/abae20f89fd88d761317267d7ceeb226e84a78ca/pyiceberg/catalog/rest/__init__.py#L312-L314

The open api specifications don't define the logic for setting the prefix path variable. This means it can be considered an implicit convention. On the other hand, it is also true that this is the standard method for HTTP redirects from the server.

My proposal is to treat the existing catalogName option as a client-specified prefix catalog property, and then construct the API path according to this implicit convention.

If the server specifies a prefix catalog property via configuration API, the server-specified property (overrides) takes precedence over the client-specified property.
-  If neither the catalogName nor warehouse option is specified, the behavior remains unchanged from previous versions.
-  If the catalogName option is specified, the behavior remains unchanged from previous versions.
-  If the warehouse option is specified, the client sends a request to the catalog server's configuration API and respects the prefix parameter in the response.
- If both the catalogName and warehouse options are specified (and server specifies prefix), the server-specified option takes precedence.

## Additional context

Fixes: https://github.com/supabase/iceberg-js/issues/32
