### PR TITLE
chore: release iceberg-js as 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
-    "docs": "typedoc src/index.ts",
+    "docs": "pnpm gen:spec-types && typedoc src/index.ts",
     "format": "prettier --write .",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
       "release-type": "node",
       "package-name": "iceberg-js",
       "changelog-path": "CHANGELOG.md",
-      "bump-minor-pre-major": true,
+      "release-as": "1.0.0",
+      "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false
     }
   }


### PR DESCRIPTION
## Summary

- Adds `release-as: "1.0.0"` to `release-please-config.json` so the open release-please PR ([#45](https://github.com/supabase/iceberg-js/pull/45)) is retitled and bumped from `0.9.0` to `1.0.0`.
- Flips `bump-minor-pre-major: false` so future `feat!` commits bump major correctly post-1.0 (no-op until then).

## Why

The README, migration guide, and `feat!: align with Iceberg REST OpenAPI spec for v1` framing all call this the **V1** release. Shipping it as `0.9.0` would be inconsistent with that messaging.

The release itself is low-risk: every external consumer pins `^0.8.1`, which won't auto-resolve to `1.0.0` (caret on 0.x treats 0.x as major), so nothing auto-breaks downstream.

## Test plan

- [ ] Merging this triggers release-please to update PR #45 with version `1.0.0` and a regenerated changelog
- [ ] After PR #45 merges and publishes, remove the `release-as` key in a follow-up commit so subsequent releases compute normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)